### PR TITLE
Improve round results UI and content

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -56,7 +56,7 @@ import { MatBadgeModule } from '@angular/material/badge';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-
+import { MatChipsModule } from '@angular/material/chips';
 import { ClipboardModule } from '@angular/cdk/clipboard';
 
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
@@ -97,6 +97,7 @@ import { HeaderV2Component } from './landing/header-v2/header-v2.component';
 import { HomeComponent } from './landing/home/home.component';
 import { WrapperComponent } from './landing/wrapper/wrapper.component';
 import { StarRatingComponent } from './shared/star-rating/star-rating.component';
+import { RoundResultsComponent } from './room/round-results/round-results.component';
 
 let appCheckToken: AppCheckToken;
 type FetchAppCheckTokenData = { token: string; expiresAt: number };
@@ -170,6 +171,7 @@ function loadAppConfig(): Promise<any> {
     HomeComponent,
     WrapperComponent,
     StarRatingComponent,
+    RoundResultsComponent,
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'serverApp' }),
@@ -236,6 +238,7 @@ function loadAppConfig(): Promise<any> {
     MatProgressBarModule,
     MatSidenavModule,
     MatBadgeModule,
+    MatChipsModule,
     ClipboardModule,
     FormsModule,
     ReactiveFormsModule,

--- a/src/app/landing/home/home.component.html
+++ b/src/app/landing/home/home.component.html
@@ -2,7 +2,7 @@
   <div class="hero-header">
     <div class="header-intro">
       <h1>
-        Real-time online planning poker<br />
+        Real-time online planning poker <wbr />
         for remote scrum teams
       </h1>
       <p>Better estimation sessions for the whole team.</p>

--- a/src/app/room/room.component.html
+++ b/src/app/room/room.component.html
@@ -48,125 +48,16 @@
         >
           <div>
             <mat-card-content>
-              <mat-list>
-                <ng-container *ngIf="(room?.rounds)[currentRound].show_results">
-                  <h3 matSubheader>Statistics</h3>
-                  <mat-list-item>
-                    <h3 matLine class="statistic">
-                      Average
-                      <span>{{
-                        roundStatistics[currentRound]?.average
-                          | number
-                          | estimateConverter
-                            : selectedEstimationCardSetValue
-                            : "rounded"
-                      }}</span>
-                    </h3>
-                  </mat-list-item>
-                  <mat-list-item>
-                    <h3 matLine class="statistic">
-                      Highest
-                      <span>
-                        {{
-                          roundStatistics[currentRound]?.highestVote.value
-                            | estimateConverter
-                              : selectedEstimationCardSetValue
-                              : "exact"
-                        }}
-                        ({{
-                          roundStatistics[currentRound]?.highestVote.voter
-                        }})</span
-                      >
-                    </h3>
-                  </mat-list-item>
-                  <mat-list-item>
-                    <h3 matLine class="statistic">
-                      Lowest
-                      <span>
-                        {{
-                          roundStatistics[currentRound]?.lowestVote.value
-                            | estimateConverter
-                              : selectedEstimationCardSetValue
-                              : "exact"
-                        }}
-                        ({{
-                          roundStatistics[currentRound]?.lowestVote.voter
-                        }})</span
-                      >
-                    </h3>
-                  </mat-list-item>
-                </ng-container>
-
-                <h3 matSubheader>Votes</h3>
-                <mat-list-item *ngFor="let member of members$ | async">
-                  <span matListItemAvatar class="avatar">
-                    <img
-                      *ngIf="member.avatarUrl"
-                      [src]="member.avatarUrl"
-                      class="avatar-image"
-                      alt="A user's avatar"
-                    />
-                    <div class="avatar-text" *ngIf="!member.avatarUrl">
-                      {{ member.name?.charAt(0) }}
-                    </div>
-                  </span>
-                  <h3 matLine class="member">
-                    {{ member.name }}
-                    <span
-                      class="estimate"
-                      *ngIf="member.type === MemberType.ESTIMATOR"
-                    >
-                      <span
-                        *ngIf="
-                          (room?.rounds)[currentRound].estimates[member.id] !=
-                            undefined &&
-                          (room?.rounds)[currentRound].show_results
-                        "
-                        >{{
-                          (room?.rounds)[currentRound].estimates[member.id]
-                            | estimateConverter
-                              : selectedEstimationCardSetValue
-                              : "exact"
-                        }}</span
-                      >
-                      <span
-                        *ngIf="
-                          (room?.rounds)[currentRound].estimates[member.id] ==
-                            undefined &&
-                          (room?.rounds)[currentRound].show_results
-                        "
-                        >Not voted</span
-                      >
-                      <div
-                        class="vote-status-container"
-                        *ngIf="
-                          (room?.rounds)[currentRound].estimates[member.id] ==
-                            undefined &&
-                          !(room?.rounds)[currentRound].show_results
-                        "
-                      >
-                        <span>Waiting to vote</span>
-                      </div>
-                      <div
-                        class="vote-status-container"
-                        *ngIf="
-                          (room?.rounds)[currentRound].estimates[member.id] !=
-                            undefined &&
-                          !(room?.rounds)[currentRound].show_results
-                        "
-                      >
-                        <span>Voted</span>
-                      </div>
-                    </span>
-                    <span
-                      class="observer vote-status-container"
-                      *ngIf="member.type === MemberType.OBSERVER"
-                    >
-                      Observing
-                    </span>
-                  </h3>
-                </mat-list-item>
-              </mat-list>
+              <app-round-results
+                [room]="room"
+                [roundStatistics]="roundStatistics"
+                [members]="members$ | async"
+                [currentRound]="currentRound"
+                [selectedEstimationCardSetValue]="
+                  selectedEstimationCardSetValue
+                "
+              >
+              </app-round-results>
             </mat-card-content>
             <div class="card-footer-actions extra-padding">
               <app-notes-field [room]="room"></app-notes-field>

--- a/src/app/room/room.component.html
+++ b/src/app/room/room.component.html
@@ -109,7 +109,7 @@
               </div>
             </button>
           </div>
-          <mat-card-footer class="card-footer">
+          <mat-card-footer class="room-id-container">
             <h4>
               <span
                 >Room ID: <strong>{{ room?.roomId }}</strong></span

--- a/src/app/room/room.component.scss
+++ b/src/app/room/room.component.scss
@@ -71,17 +71,6 @@
   }
 }
 
-.vote-status-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  font-size: 0.8rem;
-
-  opacity: 0.7;
-  
-}
-
 .action-buttons-container {
   display: flex;
   flex-wrap: wrap;

--- a/src/app/room/room.component.ts
+++ b/src/app/room/room.component.ts
@@ -15,13 +15,11 @@ import { UntypedFormControl } from '@angular/forms';
 import { Clipboard } from '@angular/cdk/clipboard';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import {
-  catchError,
   combineLatest,
   distinctUntilChanged,
   filter,
   map,
   Observable,
-  of,
   share,
   startWith,
   Subject,
@@ -495,7 +493,29 @@ export class RoomComponent implements OnInit, OnDestroy {
       const lowest = estimates[0];
       const highest = estimates[estimates.length - 1];
 
-      return { average, elapsed, lowestVote: lowest, highestVote: highest };
+      const votesCount: { [estimateKey: string]: number } = estimates.reduce(
+        (acc, curr) => {
+          acc[curr.value] = acc[curr.value] ? acc[curr.value] + 1 : 1;
+          return acc;
+        },
+        {}
+      );
+
+      // [estimateKey, numberOfVotes]
+      const mostPopularVoteEntry: [string, number] = Object.entries<number>(
+        votesCount
+      ).sort((a, b) => b[1] - a[1])[0];
+
+      return {
+        average,
+        elapsed,
+        lowestVote: lowest,
+        highestVote: highest,
+        consensus: {
+          value: +mostPopularVoteEntry[0],
+          isConsensus: mostPopularVoteEntry[1] === estimates.length
+        }
+      };
     }
   }
 

--- a/src/app/room/round-results/round-results.component.html
+++ b/src/app/room/round-results/round-results.component.html
@@ -34,7 +34,7 @@
             <mat-chip>
               {{
                 statistics.average
-                  | number
+                  | number : "1.0-1"
                   | estimateConverter
                     : selectedEstimationCardSetValue
                     : "rounded"

--- a/src/app/room/round-results/round-results.component.html
+++ b/src/app/room/round-results/round-results.component.html
@@ -1,0 +1,139 @@
+<mat-list>
+  <ng-container *ngIf="(room?.rounds)[currentRound].show_results">
+    <ng-container *ngIf="roundStatistics[currentRound] as statistics">
+      <h3 matSubheader>Statistics</h3>
+      <mat-list-item>
+        <h3 matLine class="statistic">
+          <div>Result</div>
+          <div>
+            <mat-chip-set>
+              <mat-chip
+                class="consensus"
+                *ngIf="statistics.consensus.isConsensus"
+                matTooltip="Easier done than said! Everyone voted the same way in this round."
+              >
+                <span matChipAvatar>🎉</span>
+                <strong>Consensus</strong>
+              </mat-chip>
+              <mat-chip matTooltip="This option got the most votes.">
+                {{
+                  statistics.consensus.value
+                    | estimateConverter
+                      : selectedEstimationCardSetValue
+                      : "exact"
+                }}
+              </mat-chip>
+            </mat-chip-set>
+          </div>
+        </h3>
+      </mat-list-item>
+      <mat-list-item>
+        <h3 matLine class="statistic">
+          Average
+          <mat-chip-set>
+            <mat-chip>
+              {{
+                statistics.average
+                  | number
+                  | estimateConverter
+                    : selectedEstimationCardSetValue
+                    : "rounded"
+              }}
+            </mat-chip>
+          </mat-chip-set>
+        </h3>
+      </mat-list-item>
+      <mat-list-item>
+        <h3 matLine class="statistic">
+          Highest
+          <mat-chip-set>
+            <mat-chip class="voter">
+              {{ statistics.highestVote.voter }}
+            </mat-chip>
+            <mat-chip>
+              {{
+                statistics.highestVote.value
+                  | estimateConverter : selectedEstimationCardSetValue : "exact"
+              }}
+            </mat-chip>
+          </mat-chip-set>
+        </h3>
+      </mat-list-item>
+      <mat-list-item>
+        <h3 matLine class="statistic">
+          Lowest
+          <mat-chip-set>
+            <mat-chip class="voter">
+              {{ statistics.lowestVote.voter }}
+            </mat-chip>
+            <mat-chip>
+              {{
+                statistics.lowestVote.value
+                  | estimateConverter : selectedEstimationCardSetValue : "exact"
+              }}
+            </mat-chip>
+          </mat-chip-set>
+        </h3>
+      </mat-list-item>
+    </ng-container>
+  </ng-container>
+
+  <h3 matSubheader>Votes</h3>
+  <mat-list-item *ngFor="let member of members">
+    <span matListItemAvatar class="avatar">
+      <img
+        *ngIf="member.avatarUrl"
+        [src]="member.avatarUrl"
+        class="avatar-image"
+        alt="A user's avatar"
+      />
+      <div class="avatar-text" *ngIf="!member.avatarUrl">
+        {{ member.name?.charAt(0) }}
+      </div>
+    </span>
+    <h3 matLine class="member">
+      {{ member.name }}
+      <mat-chip-set>
+        <ng-container *ngIf="member.type === MemberType.ESTIMATOR">
+          <mat-chip
+            *ngIf="
+              (room?.rounds)[currentRound].estimates[member.id] != undefined &&
+              (room?.rounds)[currentRound].show_results
+            "
+            >{{
+              (room?.rounds)[currentRound].estimates[member.id]
+                | estimateConverter : selectedEstimationCardSetValue : "exact"
+            }}</mat-chip
+          >
+          <mat-chip
+            *ngIf="
+              (room?.rounds)[currentRound].estimates[member.id] == undefined &&
+              (room?.rounds)[currentRound].show_results
+            "
+          >
+            Not voted
+          </mat-chip>
+          <mat-chip
+            *ngIf="
+              (room?.rounds)[currentRound].estimates[member.id] == undefined &&
+              !(room?.rounds)[currentRound].show_results
+            "
+          >
+            Waiting to vote
+          </mat-chip>
+          <mat-chip
+            *ngIf="
+              (room?.rounds)[currentRound].estimates[member.id] != undefined &&
+              !(room?.rounds)[currentRound].show_results
+            "
+          >
+            Voted
+          </mat-chip>
+        </ng-container>
+        <mat-chip *ngIf="member.type === MemberType.OBSERVER">
+          Observing
+        </mat-chip>
+      </mat-chip-set>
+    </h3>
+  </mat-list-item>
+</mat-list>

--- a/src/app/room/round-results/round-results.component.scss
+++ b/src/app/room/round-results/round-results.component.scss
@@ -1,0 +1,17 @@
+mat-chip-set {
+    display: inline-flex;
+  
+    mat-chip {
+      &.consensus {
+        background: var(--accent-color);
+  
+        strong {
+          color: white;
+        }
+      }
+  
+      &.voter {
+        background: #d9e2ff;
+      }
+    }
+  }

--- a/src/app/room/round-results/round-results.component.spec.ts
+++ b/src/app/room/round-results/round-results.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RoundResultsComponent } from './round-results.component';
+
+describe('RoundResultsComponent', () => {
+  let component: RoundResultsComponent;
+  let fixture: ComponentFixture<RoundResultsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RoundResultsComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(RoundResultsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/room/round-results/round-results.component.ts
+++ b/src/app/room/round-results/round-results.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { Observable } from 'rxjs';
+import { CardSetValue, Member, MemberType, Room, RoundStatistics } from 'src/app/types';
+
+@Component({
+  selector: 'app-round-results',
+  templateUrl: './round-results.component.html',
+  styleUrls: ['./round-results.component.scss']
+})
+export class RoundResultsComponent {
+  @Input() room: Room;
+  @Input() roundStatistics: RoundStatistics;
+  @Input() members: Member[];
+  @Input() currentRound: number;
+  @Input() selectedEstimationCardSetValue: CardSetValue;
+
+  readonly MemberType = MemberType;
+}

--- a/src/app/room/topics-sidebar/topics-sidebar.component.html
+++ b/src/app/room/topics-sidebar/topics-sidebar.component.html
@@ -41,7 +41,6 @@
               mat-menu-item
               aria-label="View the results of the given round"
               (click)="detailsPanel.toggle()"
-              [disabled]="roundNumber === currentRound"
             >
               Details
             </button>
@@ -74,116 +73,25 @@
           <div class="blob green" *ngIf="roundNumber === currentRound"></div>
           {{ round.topic }}
         </h3>
-        <div class="card-round-result">
-          <span
-            class="result-container"
-            *ngIf="
-              roundNumber !== currentRound &&
-              roundStatistics &&
-              roundStatistics[roundNumber] !== undefined
-            "
-          >
-            {{
-              roundStatistics[roundNumber]?.average
-                | number
-                | estimateConverter : selectedEstimationCardSetValue : "rounded"
-            }}
-          </span>
-        </div>
 
         <mat-expansion-panel
           class="flat-accordion"
-          [disabled]="roundNumber === currentRound"
           #detailsPanel
         >
           <ng-template matExpansionPanelContent>
-            <mat-list>
-              <h3 matSubheader *ngIf="roundStatistics[roundNumber]">
-                Statistics
-              </h3>
-              <mat-list-item *ngIf="roundStatistics[roundNumber]?.average">
-                <h3 matLine class="statistic">
-                  Average
-                  <span>{{
-                    roundStatistics[roundNumber]?.average
-                      | number
-                      | estimateConverter
-                        : selectedEstimationCardSetValue
-                        : "rounded"
-                  }}</span>
-                </h3>
-              </mat-list-item>
-              <mat-list-item *ngIf="roundStatistics[roundNumber]?.highestVote">
-                <h3 matLine class="statistic">
-                  Highest
-                  <span>
-                    {{
-                      roundStatistics[roundNumber]?.highestVote.value
-                        | estimateConverter
-                          : selectedEstimationCardSetValue
-                          : "exact"
-                    }}
-                    ({{
-                      roundStatistics[roundNumber]?.highestVote.voter
-                    }})</span
-                  >
-                </h3>
-              </mat-list-item>
-              <mat-list-item *ngIf="roundStatistics[roundNumber]?.lowestVote">
-                <h3 matLine class="statistic">
-                  Lowest
-                  <span>
-                    {{
-                      roundStatistics[roundNumber]?.lowestVote.value
-                        | estimateConverter
-                          : selectedEstimationCardSetValue
-                          : "exact"
-                    }}
-                    ({{ roundStatistics[roundNumber]?.lowestVote.voter }})</span
-                  >
-                </h3>
-              </mat-list-item>
-              <mat-list-item *ngIf="roundStatistics[roundNumber]?.elapsed">
-                <h3 matLine class="statistic">
-                  Elapsed time
-                  <span> {{ roundStatistics[roundNumber]?.elapsed }}</span>
-                </h3>
-              </mat-list-item>
-              <h3 matSubheader>Votes</h3>
-              <mat-list-item *ngFor="let member of room?.members">
-                <span matListItemAvatar class="avatar">
-                  <img
-                    *ngIf="member.avatarUrl"
-                    [src]="member.avatarUrl"
-                    class="avatar-image"
-                    alt="A user's avatar"
-                  />
-                  <div class="avatar-text" *ngIf="!member.avatarUrl">
-                    {{ member.name?.charAt(0) }}
-                  </div>
-                </span>
-                <h3 matLine class="member">
-                  {{ member.name }}
-                  <span class="estimate">
-                    <span *ngIf="member.type === MemberType.ESTIMATOR">{{
-                      round.estimates[member.id] == undefined
-                        ? "Not voted"
-                        : (round.estimates[member.id]
-                          | estimateConverter
-                            : selectedEstimationCardSetValue
-                            : "exact")
-                    }}</span>
-                    <span *ngIf="member.type === MemberType.OBSERVER">
-                      Observer
-                    </span>
-                  </span>
-                </h3>
-              </mat-list-item>
-              <h3 matSubheader>Notes</h3>
-              <div class="note-wrapper">
-                <p [innerText]="round.notes?.note || 'No notes taken.'"></p>
-              </div>
-            </mat-list>
+            <app-round-results
+              [room]="room"
+              [roundStatistics]="roundStatistics"
+              [members]="room.members"
+              [currentRound]="roundNumber"
+              [selectedEstimationCardSetValue]="selectedEstimationCardSetValue"
+            >
+            </app-round-results>
+
+            <h3 matSubheader>Notes</h3>
+            <div class="note-wrapper">
+              <p [innerText]="round.notes?.note || 'No notes taken.'"></p>
+            </div>
           </ng-template>
         </mat-expansion-panel>
       </mat-card-content>

--- a/src/app/room/topics-sidebar/topics-sidebar.component.scss
+++ b/src/app/room/topics-sidebar/topics-sidebar.component.scss
@@ -110,3 +110,9 @@
     background: white;
   }
 }
+
+.card-round-number {
+  color: #001A43;
+  font-weight: bold;
+  font-size: 0.8rem;
+}

--- a/src/app/shared/session-history/session-history.component.html
+++ b/src/app/shared/session-history/session-history.component.html
@@ -46,7 +46,7 @@
                   matListItemMeta
                   class="round-average"
                   *ngIf="round.average !== ''"
-                  >{{ round.average }}</span
+                  >{{ round.average | number:'1.0-1' }}</span
                 >
               </mat-list-item>
             </mat-list>

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -21,7 +21,7 @@ export interface Timer {
   initialCountdownLength: number;
   countdownLength: number;
   extraSecondsAdded: number;
-  startedAt: FieldValue|null;
+  startedAt: FieldValue | null;
   state: TimerState;
 }
 
@@ -90,6 +90,7 @@ export interface RoundStatistics {
     voter: string;
   };
   elapsed?: string;
+  consensus: { value: number; isConsensus: boolean };
 }
 
 export type CardSetValue = {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -8,9 +8,9 @@
   --accent-color: #f5a115;
   --light-background-color: #f4f5f6;
 
-  --text-on-white: #3F4759;
-  --text-on-gray: #44474F;
-  --background-dark: #001A43;
+  --text-on-white: #3f4759;
+  --text-on-gray: #44474f;
+  --background-dark: #001a43;
 }
 
 * {
@@ -25,7 +25,6 @@ body {
 body {
   margin: 0;
   background: var(--background-dark);
-
 }
 
 .mat-mdc-menu-panel {
@@ -44,28 +43,19 @@ $my-theme: mat.define-light-theme(
   )
 );
 
-
 @include mat.core();
 @include mat.all-component-themes($my-theme);
 
-.card-footer {
+.room-id-container {
   padding: 1rem !important;
   border-top: 0.5px solid lightgrey;
-  h3,
+
   h4 {
     margin: 0;
     display: flex;
     justify-content: space-between;
     align-items: center;
-
-    small {
-      cursor: pointer;
-      color: #f5a115;
-
-      &:hover {
-        font-weight: bold;
-      }
-    }
+    gap: 0.5rem;
 
     button {
       flex-shrink: 0;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -130,6 +130,7 @@ $my-theme: mat.define-light-theme(
   display: flex !important;
   flex-direction: row;
   justify-content: space-between;
+  align-items: center;
   margin-bottom: 0 !important;
 }
 
@@ -137,10 +138,6 @@ $my-theme: mat.define-light-theme(
   display: flex !important;
   flex-direction: row;
   justify-content: space-between;
-
-  span {
-    color: #f5a115;
-  }
 }
 
 .note-wrapper {


### PR DESCRIPTION
Improves the round statistics and results view and unifies how it's shown on the main page and the sidebar.
Also, this adds a "Result" row that shows the card with the most votes. This can later be improved so the final result can be edited.


<img width="892" alt="image" src="https://user-images.githubusercontent.com/17903881/210006339-418ef38d-300b-4cf5-87ff-13e6ad12da78.png">
