### PR TITLE
fix: use light-on-dark FAQ styling on knowledge base articles

### DIFF
--- a/src/app/landing/blog/article/article.component.html
+++ b/src/app/landing/blog/article/article.component.html
@@ -43,9 +43,14 @@
               </div>
             </div>
             @if (article.faqs?.length > 0) {
+              <!--
+                No [inverse] here: that variant forces text to #000 for a light
+                background, but the article page is dark (main is transparent,
+                article text is white), so it rendered black on dark. The
+                default light-on-dark styling matches the rest of the page.
+              -->
               <app-faq-section
                 [faqs]="article.faqs"
-                [inverse]="true"
                 [hideMoreButton]="true"
                 [hideTitle]="true" />
             }


### PR DESCRIPTION
## Problem

FAQ answers on `/knowledge-base/<slug>` render as **black text on the dark page background** — effectively unreadable.

## Cause

`article.component.html` passed `[inverse]="true"` to `app-faq-section`.

That modifier forces text to `#000` for use on a light background — but it **only overrides colours, it never sets a background**. Meanwhile the article page is dark throughout:

```scss
main    { background: transparent; }
article { color: white; }
```

So the black text landed directly on the dark page. The blog was the **only** caller passing `inverse`; every other usage (home, integration pages, printable cards) uses the default.

## Fix

One-line template change: drop the binding, so the FAQ uses its default light-on-dark styling — `#d9e2ff` titles and answers, white links, white expansion indicator. That's what the identical component already renders everywhere else on the site.

## Verification

Against a real production build, the prerendered markup for an article with FAQs now emits:

```
class="faq-section"
class="mat-expansion-panel"
```

— no `.inverse` on either. The only remaining `inverse` strings in the output are dead CSS rule definitions in the inlined stylesheet.

## Two follow-ups worth knowing about (not changed here)

1. **`inverse` is now completely unused.** It exists on both `faq-section` and `faq-row` but nothing passes it. As written it's a trap — any future caller gets the same unreadable result, because it changes text colour without changing the background. Worth either deleting or giving it a real background.

2. **`var(--background-color)` is never defined.** Both FAQ components do `background: var(--background-color)`, but that variable doesn't exist anywhere in the codebase — `styles.scss` defines `--light-background-color`, `--on-light-background-color` and `--highlight-background-color`, but not this one. It resolves to nothing, which is *why* the section is transparent and inherits the page background. Harmless today since transparent happens to be what we want, but it's accidental rather than intentional.

Happy to take either in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)