### PR TITLE
feat(seo): add keyword-led h1 above the homepage display headline

### DIFF
--- a/src/app/landing/components/page-header-with-cta/page-header-with-cta.component.html
+++ b/src/app/landing/components/page-header-with-cta/page-header-with-cta.component.html
@@ -1,13 +1,19 @@
 <div class="hero-header-section">
   <div class="hero-header">
     <div class="header-intro">
-      <h1>@for (segment of titleSegments; track segment.text) {
+      <ng-template #heroTitle>@for (segment of titleSegments; track segment.text) {
         @if (segment.highlighted) {
           <span class="highlight-marker">{{ segment.text }}</span>
         } @else {
           <span>{{ segment.text }}</span>
         }
-      }</h1>
+      }</ng-template>
+      @if (config.eyebrow) {
+        <h1 class="hero-eyebrow">{{ config.eyebrow }}</h1>
+        <h2 class="hero-title"><ng-container *ngTemplateOutlet="heroTitle" /></h2>
+      } @else {
+        <h1 class="hero-title"><ng-container *ngTemplateOutlet="heroTitle" /></h1>
+      }
       <p class="header-description">
         {{ config.description }}
       </p>

--- a/src/app/landing/components/page-header-with-cta/page-header-with-cta.component.scss
+++ b/src/app/landing/components/page-header-with-cta/page-header-with-cta.component.scss
@@ -32,7 +32,18 @@
       }
     }
 
-    h1 {
+    .hero-eyebrow {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: clamp(0.8rem, 1.4vw, 0.95rem);
+      line-height: 1.2;
+      font-weight: 400;
+      margin: 0 0 0.75rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: #fff;
+    }
+
+    .hero-title {
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
       font-size: clamp(2.5rem, 5vw, 3.8rem);
       line-height: 1.15;
@@ -578,7 +589,13 @@
       padding-bottom: 3rem;
       text-align: center;
 
-      h1 {
+      .hero-eyebrow {
+        font-size: 0.75rem;
+        letter-spacing: 0.1em;
+        margin-bottom: 0.5rem;
+      }
+
+      .hero-title {
         font-size: 1.5rem;
         line-height: 1.7rem;
       }

--- a/src/app/landing/components/page-header-with-cta/page-header-with-cta.component.ts
+++ b/src/app/landing/components/page-header-with-cta/page-header-with-cta.component.ts
@@ -2,13 +2,20 @@ import { Component, Input, OnDestroy, PLATFORM_ID, inject, afterNextRender, sign
 import { RouterLink } from '@angular/router';
 import { MatAnchor } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
-import { isPlatformBrowser } from '@angular/common';
+import { isPlatformBrowser, NgTemplateOutlet } from '@angular/common';
 import {
   PlatformChromeConfig,
   PlatformMeetingChromeComponent,
 } from '../platform-meeting-chrome/platform-meeting-chrome.component';
 
 export interface HeaderConfig {
+  /**
+   * Optional short kicker rendered above the display headline. When set it
+   * becomes the page's h1 and the headline drops to h2, so the primary
+   * heading can match the search result title while the headline stays the
+   * dominant visual element. Pages that omit it keep the headline as h1.
+   */
+  eyebrow?: string;
   title: string;
   titleHighlights?: string[];
   description: string;
@@ -50,7 +57,13 @@ interface TitleSegment {
   selector: 'planning-poker-page-header-with-cta',
   templateUrl: './page-header-with-cta.component.html',
   styleUrl: './page-header-with-cta.component.scss',
-  imports: [MatIcon, MatAnchor, RouterLink, PlatformMeetingChromeComponent],
+  imports: [
+    MatIcon,
+    MatAnchor,
+    RouterLink,
+    PlatformMeetingChromeComponent,
+    NgTemplateOutlet,
+  ],
 })
 export class PageHeaderWithCtaComponent implements OnDestroy {
   @Input({ required: true }) config!: HeaderConfig;

--- a/src/app/landing/home/home.component.html
+++ b/src/app/landing/home/home.component.html
@@ -4,6 +4,7 @@
 </div> -->
 <planning-poker-page-header-with-cta
   [config]="{
+    eyebrow: 'Free Online Planning Poker',
     title: 'Planning Poker for Dev Teams That Ship',
     titleHighlights: ['Dev Teams', 'Ship'],
     description:


### PR DESCRIPTION
## What changed

The homepage h1 was **"Planning Poker for Dev Teams That Ship"** — good copy, but it targets a phrase nobody searches for.

This adds a small kicker above it as the **h1** — "Free Online Planning Poker" — and drops the display headline to **h2**. The headline stays the dominant visual element; only the heading level changes.

```
h1  FREE ONLINE PLANNING POKER      ← small, uppercase, white, weight 400
h2  Planning Poker for
    Dev Teams That Ship             ← unchanged visually
```

## Implementation note

`PageHeaderWithCtaComponent` is shared with the **Zoom, Teams and Meet** integration pages, so this is an optional `eyebrow` field on `HeaderConfig` rather than a homepage-only edit. When `eyebrow` is absent, those pages keep the headline as their `h1` and their heading structure is completely untouched.

The title segment markup moved into an `ng-template` so the h1 and h2 branches share it instead of duplicating the highlight loop. SCSS rules that targeted the bare `h1` selector now target `.hero-title`, so display styling follows the headline regardless of level — both the desktop rule and the small-screen override.

## Verified against a production build

| Page | h1 count | h1 content |
|---|---|---|
| `/` | 1 | `Free Online Planning Poker` (eyebrow) |
| `/integrations/zoom` | hero h1 intact | `Planning Poker for …` |
| `/integrations/teams` | hero h1 intact | `Planning Poker for …` |
| `/integrations/meet` | hero h1 intact | `Planning Poker for …` |

## ⚠️ Two things to decide before/after merging

**1. The new h1 doesn't match the SERP title.** The intent was to match the search result exactly, but the homepage title tag is currently:

> `Planning Poker for Developers - Free Scrum Estimation Tool`

So "Free Online Planning Poker" reinforces a *different* phrase. That's not necessarily wrong — h1 and title don't have to match, and "free online planning poker" is closer to real search demand (`online` and `free` are both top autocomplete completions for "planning poker", whereas "for developers" is not). But if exact SERP alignment is the goal, the title tag in `landing.module.ts:11` needs changing too. I did **not** touch it — rewriting the homepage title affects existing rankings and is worth deciding deliberately.

**2. Pre-existing: the integration pages have two h1s each.** The hero renders one, and a second component further down the page renders another with `class="title"`. This predates the change and isn't a ranking penalty, but it does muddy the heading structure. Happy to clean up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)