### PR TITLE
feat(seo): emit Article, BreadcrumbList and FAQPage as a JSON-LD graph

### DIFF
--- a/src/app/landing/blog/article/article.component.ts
+++ b/src/app/landing/blog/article/article.component.ts
@@ -9,11 +9,35 @@ import { StartPlanningCtaComponent } from '../../components/start-planning-cta/s
 import { MarkdownComponent } from 'ngx-markdown';
 import { NgOptimizedImage, AsyncPipe, DatePipe } from '@angular/common';
 import { SchemaTagService } from 'src/app/services/schema-tag.service';
-import type { Article as SchemaArticle, WithContext } from 'schema-dts';
+import type {
+  Article as SchemaArticle,
+  BreadcrumbList as SchemaBreadcrumbList,
+  FAQPage as SchemaFAQPage,
+  WithContext,
+} from 'schema-dts';
 import { YoutubePlayerComponent } from 'src/app/shared/youtube-player/youtube-player.component';
 import { FaqSectionComponent } from '../../faq/faq-section/faq-section.component';
-import { PageHeaderComponent, Breadcrumb } from '../../components/page-header/page-header.component';
+import {
+  PageHeaderComponent,
+  Breadcrumb,
+} from '../../components/page-header/page-header.component';
 import { toSignal } from '@angular/core/rxjs-interop';
+
+const ARTICLE_BASE_URL = 'https://planningpoker.live/knowledge-base';
+const CLOUDINARY_BASE = 'https://res.cloudinary.com/dtvhnllmc/image/upload';
+
+/** 16:9, 4:3 and 1:1 crops of one Cloudinary asset, as Google recommends. */
+function coverImageVariants(coverImageId: string): string[] {
+  return ['16:9', '4:3', '1:1'].map(
+    ratio =>
+      `${CLOUDINARY_BASE}/c_fill,ar_${ratio},w_1200/v1736183590/${coverImageId}`
+  );
+}
+
+/** Rough word count of the markdown body, good enough for wordCount. */
+function countWords(content: string): number {
+  return content.trim().split(/\s+/).filter(Boolean).length;
+}
 
 @Component({
   selector: 'app-article',
@@ -30,7 +54,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
     YoutubePlayerComponent,
     FaqSectionComponent,
     PageHeaderComponent,
-],
+  ],
 })
 export class ArticleComponent {
   private readonly metaService = inject(Meta);
@@ -52,7 +76,7 @@ export class ArticleComponent {
         { name: 'author', content: article.author },
         {
           property: 'og:url',
-          content: `https://planningpoker.live/blog/${article.slug}`,
+          content: `${ARTICLE_BASE_URL}/${article.slug}`,
         },
         { property: 'og:type', content: 'article' },
         { property: 'og:site_name', content: 'PlanningPoker.live' },
@@ -73,13 +97,18 @@ export class ArticleComponent {
         },
       ]);
 
-      const schema: WithContext<SchemaArticle> = {
+      const url = `${ARTICLE_BASE_URL}/${article.slug}`;
+      const publishedAt = new Date(article.lastUpdated).toISOString();
+
+      const articleNode: WithContext<SchemaArticle> = {
         '@context': 'https://schema.org',
         '@type': 'Article',
         headline: article.title,
         description: article.description,
-        datePublished: new Date(article.lastUpdated).toISOString(),
-        dateModified: new Date(article.lastUpdated).toISOString(),
+        // The article model carries a single date, so published and modified
+        // are necessarily the same value here.
+        datePublished: publishedAt,
+        dateModified: publishedAt,
         author: {
           '@type': 'Person',
           name: article.author,
@@ -92,19 +121,62 @@ export class ArticleComponent {
             url: 'https://planningpoker.live/assets/logo.webp',
           },
         },
-        image: `https://res.cloudinary.com/dtvhnllmc/image/upload/v1736183590/${article.coverImageId}`,
+        // Google asks for 16:9, 4:3 and 1:1 crops of the same image so it can
+        // pick one per surface. Cloudinary generates them from the one asset.
+        image: coverImageVariants(article.coverImageId),
+        url,
+        mainEntityOfPage: {
+          '@type': 'WebPage',
+          '@id': url,
+        },
+        inLanguage: 'en',
+        articleSection: article.category,
+        wordCount: countWords(article.content),
         keywords: article.tags.join(', '),
       };
 
       if (article.youtubeVideoId) {
-        schema.video = {
+        articleNode.video = {
           '@type': 'VideoObject',
           name: article.title,
           description: article.description,
           thumbnailUrl: `https://img.youtube.com/vi/${article.youtubeVideoId}/maxresdefault.jpg`,
           embedUrl: `https://www.youtube.com/embed/${article.youtubeVideoId}`,
-          uploadDate: new Date(article.lastUpdated).toISOString(),
+          uploadDate: publishedAt,
         };
+      }
+
+      const breadcrumbNode: WithContext<SchemaBreadcrumbList> = {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { name: 'Home', item: 'https://planningpoker.live' },
+          { name: 'Knowledge Base', item: ARTICLE_BASE_URL },
+          { name: article.title, item: url },
+        ].map((crumb, index) => ({
+          '@type': 'ListItem' as const,
+          position: index + 1,
+          name: crumb.name,
+          item: crumb.item,
+        })),
+      };
+
+      const schema: unknown[] = [articleNode, breadcrumbNode];
+
+      if (article.faqs?.length) {
+        const faqNode: WithContext<SchemaFAQPage> = {
+          '@context': 'https://schema.org',
+          '@type': 'FAQPage',
+          mainEntity: article.faqs.map(faq => ({
+            '@type': 'Question' as const,
+            name: faq.question,
+            acceptedAnswer: {
+              '@type': 'Answer' as const,
+              text: faq.answer,
+            },
+          })),
+        };
+        schema.push(faqNode);
       }
 
       this.schemaTagService.setJsonLd(this.renderer2, schema);

--- a/src/app/services/schema-tag.service.ts
+++ b/src/app/services/schema-tag.service.ts
@@ -1,4 +1,3 @@
-
 import { Inject, Injectable, Renderer2, signal, DOCUMENT } from '@angular/core';
 import { WebApplication, WithContext } from 'schema-dts';
 import { FaqItem } from '../types';
@@ -66,25 +65,47 @@ export class SchemaTagService {
 
   constructor(@Inject(DOCUMENT) private _document: Document) {}
 
-  public setJsonLd(renderer2: Renderer2, data: any): void {
-    let script = renderer2.createElement('script');
+  /**
+   * Injects one JSON-LD block into the document head.
+   *
+   * Pass an array to describe a page with several entities - an Article plus
+   * its BreadcrumbList and FAQPage, say. They are emitted as a single @graph
+   * rather than several script tags, which is what Google recommends and
+   * keeps the cleanup below simple.
+   */
+  public setJsonLd(renderer2: Renderer2, data: unknown | unknown[]): void {
+    const payload = Array.isArray(data)
+      ? {
+          '@context': 'https://schema.org',
+          // Nodes carry their own @context when emitted alone; inside a @graph
+          // the context belongs on the wrapper, so strip the duplicates.
+          '@graph': data.map(node => {
+            const { '@context': _discarded, ...rest } = node as Record<
+              string,
+              unknown
+            >;
+            return rest;
+          }),
+        }
+      : data;
+
+    const script = renderer2.createElement('script');
     script.type = 'application/ld+json';
-    script.text = `${JSON.stringify(data)}`;
+    // script.text is textContent, so the live DOM is safe on its own. During
+    // prerendering though, Angular serializes the DOM back to an HTML string,
+    // and a literal </script> inside article copy would close this element
+    // early. \u003C is valid JSON and renders identically to a parser.
+    script.text = JSON.stringify(payload).replace(/</g, '\\u003C');
     script.setAttribute('class', 'structured-data-markup');
 
-    // Remove existing elements
-    const existing = this._document.querySelector(
-      'script.structured-data-markup'
-    );
-    if (existing) {
-      renderer2.removeChild(this._document.body, existing);
-    }
-    const defaultData = this._document.querySelector(
-      'script.default-structured-data'
-    );
-    if (defaultData) {
-      renderer2.removeChild(this._document.body, defaultData);
-    }
+    // querySelectorAll, not querySelector: a single call could previously
+    // leave earlier nodes behind, and stale schema is worse than none.
+    this._document
+      .querySelectorAll('script.structured-data-markup')
+      .forEach(node => node.remove());
+    this._document
+      .querySelectorAll('script.default-structured-data')
+      .forEach(node => node.remove());
 
     renderer2.appendChild(this._document.head, script);
   }


### PR DESCRIPTION
## What was there

Knowledge base articles shipped a single `Article` node and nothing else — no breadcrumbs, no FAQ markup, and missing most of the Article fields Google recommends.

## What this adds

`SchemaTagService.setJsonLd` now accepts an array and emits the nodes as one `@graph`, so a page can describe several entities without several script tags. Articles now emit:

| Node | Notes |
|---|---|
| `Article` | + `url`, `mainEntityOfPage`, `inLanguage`, `articleSection`, `wordCount`, and 16:9 / 4:3 / 1:1 image crops |
| `BreadcrumbList` | Home › Knowledge Base › article — rendered visually but never declared |
| `FAQPage` | from `article.faqs`, only when present |

The image crops are generated by Cloudinary from the single existing asset, so this costs no new artwork. All three URLs verified returning `200 image/webp`.

## Two bugs fixed along the way

**`og:url` pointed at a route that doesn't exist.** Every article advertised `https://planningpoker.live/blog/<slug>`, but there is no `/blog` route — the module is mounted at `knowledge-base` (`landing.module.ts:219`). Anything sharing or crawling an article got a dead URL. `og:url` and the canonical link now agree.

**Cleanup only removed the first node.** `setJsonLd` used `querySelector` where it needed `querySelectorAll`, so a second injected node could survive a navigation. Stale schema is worse than none.

## Hardening

The serialized JSON now escapes `<` as `<`. `script.text` is `textContent`, so the live DOM was never at risk — but prerendering serializes the DOM back to an HTML string, where a literal `</script>` in article copy would close the element early. Cheap insurance on content that comes from a remote bucket.

## Honest note on FAQPage value

**Google fully dropped FAQ rich results on 7 May 2026** (after restricting them to government and health sites in 2023). So this will *not* produce FAQ rich results in Google. It's included because it's still valid schema.org, Bing and DuckDuckGo still parse it, and AI crawlers use it for answer extraction — but nobody should expect a Google SERP change from it.

**`BreadcrumbList` is the part that can actually move a SERP** — breadcrumbs remain one of the rich results Google still renders.

## Verified against a production build

Parsed the emitted JSON directly:

- article with FAQs → `Article`, `BreadcrumbList`, `FAQPage`
- article without FAQs → `Article`, `BreadcrumbList`
- glossary (single-object caller) → `FAQPage`, unchanged
- homepage → `WebApplication`, untouched
- exactly one `ld+json` block per page; `og:url` matches canonical

## ⚠️ Separate issue I did not touch: the aggregateRating

`schema-tag.service.ts` and `index.html` both declare:

```json
"aggregateRating": { "ratingValue": "4.6", "ratingCount": "171" }
```

while the hero on the same page says **"rated 4.5 ⭐ by 1000+ reviewers"**. Those disagree on both the score and the count.

Beyond the inconsistency, Google's structured data policy requires aggregate ratings to come from reviews that are *visible on the page*. There are none here, which puts this at risk of a manual action against the whole site — a much bigger downside than any upside from the stars.

I've left both values alone because I don't know which figure is real or where it's sourced from. Worth deciding deliberately: reconcile the numbers and show the reviews, or drop `aggregateRating` from the markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)