### PR TITLE
fix(seo): generate sitemap.xml again after glob v10 upgrade

### DIFF
--- a/src/cli/generate_sitemap.ts
+++ b/src/cli/generate_sitemap.ts
@@ -1,4 +1,4 @@
-import { Glob } from 'glob';
+import { globSync } from 'glob';
 import * as fs from 'fs';
 
 export class SitemapGenerator {
@@ -29,42 +29,12 @@ export class SitemapGenerator {
   }
 
   process(): void {
-    new Glob(
-      this.srcDirectory + '/**/index.html',
-      (err: Error, res: string[]) => this.filesCallback(err, res)
-    );
-  }
+    const files = globSync(this.srcDirectory + '**/index.html');
 
-  private addToSitemap(file: string): void {
-    let url = file.replace(this.srcDirectory, this.baseUrl);
-    url = url.replace('/index.html', '');
-    this.sitemapContent += `
-    <url>
-        <loc>${url}</loc>
-    </url>`;
-  }
-
-  private writeSitemapToFile(): void {
-    fs.writeFile(
-      this.srcDirectory + 'sitemap.xml',
-      this.SITEMAP_HEADER + this.sitemapContent + this.SITEMAP_FOOTER,
-      (err: NodeJS.ErrnoException | null) => {
-        if (err) {
-          console.log(err.message);
-          return;
-        }
-
-        console.log(
-          `sitemap.xml successfully created in '${this.srcDirectory}'`
-        );
-      }
-    );
-  }
-
-  private filesCallback(err: Error, files: string[]): void {
-    if (err) {
-      console.log('Error', err);
-      return;
+    if (!files.length) {
+      throw new Error(
+        `No index.html files found in '${this.srcDirectory}'. Run the build before generating the sitemap.`
+      );
     }
 
     files.sort((a, b) => {
@@ -80,6 +50,32 @@ export class SitemapGenerator {
 
     this.writeSitemapToFile();
   }
+
+  private addToSitemap(file: string): void {
+    let url = file.replace(this.srcDirectory, this.baseUrl);
+    url = url.replace('/index.html', '');
+    this.sitemapContent += `
+    <url>
+        <loc>${url}</loc>
+    </url>`;
+  }
+
+  private writeSitemapToFile(): void {
+    const target = this.srcDirectory + 'sitemap.xml';
+    fs.writeFileSync(
+      target,
+      this.SITEMAP_HEADER + this.sitemapContent + this.SITEMAP_FOOTER
+    );
+    console.log(`sitemap.xml successfully created in '${this.srcDirectory}'`);
+  }
 }
 
-new SitemapGenerator().process();
+try {
+  new SitemapGenerator().process();
+} catch (error) {
+  console.error(
+    'Failed to generate sitemap.xml:',
+    error instanceof Error ? error.message : error
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## The bug

`planningpoker.live/sitemap.xml` does not exist. `src/cli/generate_sitemap.ts` used the glob v7 callback API:

```ts
new Glob(pattern, (err, res) => this.filesCallback(err, res));
```

The project is on **glob 10.5.0**, where the callback form was removed. In v10 `Glob` is a lazy iterable — passing a function as its options object constructs fine, walks nothing, and never invokes the callback. So `npm run generate-sitemap` printed nothing, **exited 0**, and never wrote `dist/estimator/browser/sitemap.xml`.

CI runs `npm run build && npm run generate-sitemap`, so every deploy kept going green while shipping a build with no sitemap. Hosting then served `/sitemap.xml` through the catch-all `**` -> `/index.html` rewrite, which is what search engines and `robots.txt`'s `Sitemap:` line have been pointing at.

## The fix

- `globSync()` instead of the removed callback constructor.
- `fs.writeFileSync` instead of the async callback write, so write errors surface.
- Exit non-zero when no `index.html` files are found or the write fails. The silent-success mode is what let this go unnoticed, so CI should now fail loudly rather than deploy a sitemap-less build.

Route selection is unchanged — same sort order, same `noindex` filter, same URL mapping.

## Verification

Run against the current build:

- `npm run generate-sitemap` writes `dist/estimator/browser/sitemap.xml`, **48 URLs from 56 prerendered pages**.
- `xmllint --noout` reports valid XML.
- The 8 excluded routes are exactly the `noindex` app pages: `create`, `history`, `integration`, `integrations/teams/configure`, `join`, `organizationInvitation`, `recurringMeeting`, `room`.
- Served the built output via `dist/estimator/server/server.mjs`: `GET /sitemap.xml` -> `200` with the real XML body.

Note for local testing: on `ng serve` the path returns `200 text/html` — that is the dev server's index fallback, not a sitemap. The file is a post-build artifact, so only `npm run build && npm run generate-sitemap` produces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)